### PR TITLE
Modernize Julia and QUBODrivers compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - version: '1.10'
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.10'
+            os: windows-latest
+            arch: x64
           - version: '1'
             os: ubuntu-latest
             arch: x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,6 @@
 ## Unreleased
 
 - Raise the minimum supported Julia version to 1.10.
-- Allow QUBODrivers 0.4 and 0.5.
+- Constrain QUBODrivers to 0.2 while newer registered releases pull an incompatible QuantumAnnealing dependency stack on Julia 1.10.
 - Test Julia 1.10 and the latest stable Julia release in CI.
 - Clean the QUBODrivers badge link and author metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Raise the minimum supported Julia version to 1.10.
+- Allow QUBODrivers 0.4 and 0.5.
+- Test Julia 1.10 and the latest stable Julia release in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,6 @@
 ## Unreleased
 
 - Raise the minimum supported Julia version to 1.10.
-- Constrain QUBODrivers to 0.2 while newer registered releases pull an incompatible QuantumAnnealing dependency stack on Julia 1.10.
+- Require QUBODrivers 0.5 now that QUBOTools 0.12.1 resolves with the modern SciML stack on Julia 1.10.
 - Test Julia 1.10 and the latest stable Julia release in CI.
 - Clean the QUBODrivers badge link and author metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Raise the minimum supported Julia version to 1.10.
 - Allow QUBODrivers 0.4 and 0.5.
 - Test Julia 1.10 and the latest stable Julia release in CI.
+- Clean the QUBODrivers badge link and author metadata.

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QuantumAnnealing = "4832667a-bab9-40a8-88f6-be9efce3ea89"
 
 [compat]
-QUBODrivers = "0.4, 0.5"
+QUBODrivers = "0.2"
 QuantumAnnealing = "0.2"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,6 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QuantumAnnealing = "4832667a-bab9-40a8-88f6-be9efce3ea89"
 
 [compat]
+QUBODrivers = "0.4, 0.5"
 QuantumAnnealing = "0.2"
-julia = "1.6"
+julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QuantumAnnealing = "4832667a-bab9-40a8-88f6-be9efce3ea89"
 
 [compat]
-QUBODrivers = "0.2"
+QUBODrivers = "0.5"
 QuantumAnnealing = "0.2"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumAnnealingInterface"
 uuid = "d8651ca0-0f93-43a8-b432-4648ccd57c1f"
-authors = ["pedromxavier <pedromxavier@psr-inc.com>"]
+authors = ["pedromxavier <pedromxavier@psr-inc.com>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
 version = "0.1.0"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # QuantumAnnealingInterface.jl
-[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/psrenergy/QUBODrivers.jl)
+[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/JuliaQUBO/QUBODrivers.jl)
 
 JuMP interface for LANL's [QuantumAnnealing.jl](https://github.com/lanl-ansi/QuantumAnnealing.jl)
 

--- a/src/QuantumAnnealingInterface.jl
+++ b/src/QuantumAnnealingInterface.jl
@@ -9,16 +9,13 @@ import QUBODrivers:
     Sample,
     SampleSet,
     @setup,
-    sample,
-    ising
+    sample
 
 @setup Optimizer begin
     name       = "Simulated Quantum Annealer"
-    sense      = :min
-    domain     = :spin
     version    = v"0.2.0"
     attributes = begin
-        "num_reads"::Integer                                     = 1_000
+        NumberOfReads["num_reads"]::Integer                      = 1_000
         "annealing_time"::Float64                                = 1.0
         "annealing_schedule"::QuantumAnnealing.AnnealingSchedule = QuantumAnnealing.AS_LINEAR
         "steps"::Integer                                         = 0
@@ -41,12 +38,11 @@ const ATTR_LIST = [
 
 function sample(sampler::Optimizer{T}) where {T}
     # Retrieve Model
-    h, J, α, β  = ising(sampler, Dict)
+    n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
     ising_model = merge(h, J)
 
     # Retrieve Attributes
-    n                  = MOI.get(sampler, MOI.NumberOfVariables())
-    m                  = MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads"))
+    m                  = MOI.get(sampler, NumberOfReads())
     silent             = MOI.get(sampler, MOI.Silent())
     annealing_time     = MOI.get(sampler, MOI.RawOptimizerAttribute("annealing_time"))
     annealing_schedule = MOI.get(sampler, MOI.RawOptimizerAttribute("annealing_schedule"))
@@ -89,7 +85,7 @@ function sample(sampler::Optimizer{T}) where {T}
         ),
     )
 
-    return SampleSet{T}(samples, metadata)
+    return SampleSet{T}(samples, metadata; sense = :min, domain = :spin)
 end
 
 function sample_states(
@@ -105,9 +101,9 @@ function sample_states(
 
     for i = 1:m
         ψ = sample_state(P, n)
-        λ = QUBOTools.value(h, J, ψ, α, β)
+        λ = QUBOTools.value(ψ, h, J, α, β)
 
-        samples[i] = Sample{T}(ψ, λ)
+        samples[i] = Sample{T,Int}(ψ, λ)
     end
 
     return samples


### PR DESCRIPTION
## Summary

- Raise the supported Julia floor to 1.10 and keep CI on Julia 1.10 plus the latest stable Julia release.
- Require QUBODrivers 0.5 now that QUBOTools 0.12.1 is registered and resolves with the modern SciML stack.
- Update the QuantumAnnealingInterface sampler adapter for QUBODrivers 0.5 / QUBOTools 0.12 APIs, including typed `NumberOfReads`, model extraction through `QUBOTools.ising`, and explicit spin/min sample-set metadata.
- Clean existing package metadata and CI badge details.

## Tests

- `git diff --check` - passed.
- `julia +1.10 /tmp/qai_test_temp_env.jl /home/bernalde/repos/QuantumAnnealingInterface.jl` - passed, `Pkg.test("QuantumAnnealingInterface")` reported 174/174 passing with QUBODrivers 0.5.0 and QUBOTools 0.12.1.
- `julia +1.12 /tmp/qai_test_temp_env.jl /home/bernalde/repos/QuantumAnnealingInterface.jl` - passed, `Pkg.test("QuantumAnnealingInterface")` reported 174/174 passing with QUBODrivers 0.5.0 and QUBOTools 0.12.1.

## Notes

- The local repository has an ignored `Manifest.toml`, so package tests were run from temporary Julia environments to avoid committing or relying on that file.
- QUBODrivers 0.5.0 with QUBOTools 0.12.1 resolved `GeometryBasics` 0.5.10, `LinearSolve` 3.82.0, `OrdinaryDiffEq` 6.111.0, `OrdinaryDiffEqCore` 3.33.1, `OrdinaryDiffEqDifferentiation` 2.9.0, and `SciMLBase` 2.155.1 in the local test environments.

Closes #2
Closes #3
