### PR TITLE
Add TagBot workflow

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,19 @@
+name: TagBot
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1.25.7
+        with:
+          # The default GITHUB_TOKEN is sufficient for standard General registry
+          # registrations. Add TagBot's `ssh` input only if tags must trigger
+          # downstream workflows such as documentation builds.
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary
- Add `.github/workflows/TagBot.yml` for Julia TagBot release automation.
- Trigger TagBot from `JuliaTagBot` issue comments after registry activity and allow manual `workflow_dispatch` runs.
- Use the default `GITHUB_TOKEN`; no additional secret is required for the standard General registry path. The workflow notes when TagBot's `ssh` input is relevant for downstream workflow triggers.

Tests
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/TagBot.yml"); puts "YAML OK"'` passed with `YAML OK`.
- `git diff --check` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` failed before package tests during precompilation of existing transitive dependencies under `QuantumAnnealing`, through `DifferentialEquations` and `OrdinaryDiffEqDifferentiation`. Representative errors were `UndefVarError: LinearVerbosity not defined` and `Method overwriting is not permitted during Module precompilation`.

Issue: https://github.com/JuliaQUBO/QuantumAnnealingInterface.jl/issues/6

Closes #6
