### PR TITLE
Document registered package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 
 JuMP interface for LANL's [QuantumAnnealing.jl](https://github.com/lanl-ansi/QuantumAnnealing.jl)
 
-## How to
+## Installation
+```julia
+import Pkg
+Pkg.add("QuantumAnnealingInterface")
+```
+
+## Usage
 ```julia
 using JuMP
 using QuantumAnnealingInterface

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ JuMP interface for LANL's [QuantumAnnealing.jl](https://github.com/lanl-ansi/Qua
 ## Installation
 ```julia
 import Pkg
+Pkg.add("JuMP")
 Pkg.add("QuantumAnnealingInterface")
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,19 @@
+using Test
+
+@testset "README installation docs" begin
+    readme = read(joinpath(dirname(@__DIR__), "README.md"), String)
+    installation = findfirst("## Installation", readme)
+    usage = findfirst("## Usage", readme)
+
+    @test occursin("Pkg.add(\"QuantumAnnealingInterface\")", readme)
+    @test installation !== nothing
+    @test usage !== nothing
+
+    if installation !== nothing && usage !== nothing
+        @test first(installation) < first(usage)
+    end
+end
+
 using QuantumAnnealingInterface: MOI, QUBODrivers, QuantumAnnealingInterface
 
 QUBODrivers.test(QuantumAnnealingInterface.Optimizer) do model

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Test
     usage = findfirst("## Usage", readme)
 
     @test occursin("Pkg.add(\"QuantumAnnealingInterface\")", readme)
+    @test occursin("Pkg.add(\"JuMP\")", readme)
     @test installation !== nothing
     @test usage !== nothing
 


### PR DESCRIPTION
Summary:
- Adds a README installation section for the registered package workflow using `Pkg.add("QuantumAnnealingInterface")`.
- Places installation before the usage example and renames the example section to `Usage`.
- Adds README tests for the install command and section ordering.

Tests:
- `julia --project=. -e 'using Test; readme = read("README.md", String); installation = findfirst("## Installation", readme); usage = findfirst("## Usage", readme); @test occursin("Pkg.add(\"QuantumAnnealingInterface\")", readme); @test installation !== nothing; @test usage !== nothing; @test first(installation) < first(usage)'` passed.
- `git diff --check` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` failed during dependency precompilation before package tests completed. The failure is in `QuantumAnnealing`/SciML dependencies: `UndefVarError: LinearVerbosity not defined` in `OrdinaryDiffEqDifferentiation` and `Method overwriting is not permitted during Module precompilation` for `DiffEqBaseChainRulesCoreExt`.

Issue:
- Closes #7
