### PR TITLE
[codex] Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # No repository secrets are required for this configuration. It uses
+  # GitHub's standard Dependabot integration for General registry packages and
+  # GitHub Actions updates.
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    groups:
+      test-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for the root Julia package and `test/` Julia environment.
- Add monthly Dependabot updates for GitHub Actions.
- Document that this configuration does not require repository secrets.

## Notes

This follows the JuliaQUBO ecosystem policy from JuliaQUBO/QUBO.jl#30 and JuliaQUBO/QUBO.jl#31: use GitHub Dependabot by default for public Julia packages that depend only on the General registry, and keep CompatHelper for custom or private registry cases.

This repository does not currently have a docs environment or docs deployment workflow, so the Dependabot-only `--skip-deploy` Documenter guard used in the reference repos is not needed here.

Closes #5.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML OK"'`
- `git diff --cached --check`
