### PR TITLE
Benchmark julia-actions/cache for CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       # - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QuantumAnnealing = "4832667a-bab9-40a8-88f6-be9efce3ea89"
 
 [compat]
+LinearSolve = "=3.82.0"
 QUBODrivers = "0.5"
 QuantumAnnealing = "0.2"
 julia = "1.10"


### PR DESCRIPTION
Summary

- Adds `julia-actions/cache@v3` to the CI matrix after `setup-julia` and before `julia-buildpkg`.
- Adds a narrow `LinearSolve = "=3.82.0"` compat constraint so the cache benchmark resolves to the last known passing SciML solver stack instead of the newer failing transitive stack.

Benchmark plan

- Compare the last successful no-cache CI run against the cache-enabled PR runs.
- Use a second run on the same branch to confirm warm-cache behavior.
- Keep this change only if CI passes on Ubuntu and Windows for Julia 1.10 and Julia 1, and the cache shows material runtime improvement.

No-cache baseline

Run: https://github.com/JuliaQUBO/QuantumAnnealingInterface.jl/actions/runs/26907220259

| Job | Total | Result |
| --- | ---: | --- |
| Julia 1.10 - ubuntu-latest - x64 | 8m13s | passed |
| Julia 1.10 - windows-latest - x64 | 11m23s | passed |
| Julia 1 - ubuntu-latest - x64 | 17m30s | passed |
| Julia 1 - windows-latest - x64 | 20m55s | passed |

Initial cache run before dependency fix

Run: https://github.com/JuliaQUBO/QuantumAnnealingInterface.jl/actions/runs/27125631482

| Job | Total | Result |
| --- | ---: | --- |
| Julia 1.10 - ubuntu-latest - x64 | 11m05s | failed in `julia-runtest` |
| Julia 1.10 - windows-latest - x64 | 14m14s | failed in `julia-runtest` |
| Julia 1 - ubuntu-latest - x64 | 22m09s | failed in `julia-runtest` |
| Julia 1 - windows-latest - x64 | 24m55s | failed in `julia-runtest` |

The first cache-enabled run reported no cache hits and saved caches, but it was not a valid benchmark because all four jobs failed. The common failure marker was `ArgumentError: nonstructural_zeros reduction requires a constant stored sparsity pattern across solves (stored nnz changed)`, caused by a newer transitive SciML solver stack.

Post-fix cache runs

Run: https://github.com/JuliaQUBO/QuantumAnnealingInterface.jl/actions/runs/27128566146

| Job | Attempt 1 | Attempt 2 | Result |
| --- | ---: | ---: | --- |
| Julia 1.10 - ubuntu-latest - x64 | 4m48s | 1m42s | passed |
| Julia 1.10 - windows-latest - x64 | 6m50s | 2m46s | passed |
| Julia 1 - ubuntu-latest - x64 | 11m56s | 16m39s | passed |
| Julia 1 - windows-latest - x64 | 11m53s | 14m13s | passed |

Observed cache behavior:

- Attempt 1 restored older branch caches from the previous cache-enabled run, then saved fresh caches for this fixed commit.
- Attempt 2 restored from attempt 1, for example `run_id=27128566146;run_attempt=1`.
- Julia 1.10 shows material warm-cache improvement: Ubuntu 8m13s no-cache to 1m42s warm, Windows 11m23s no-cache to 2m46s warm.
- Julia 1 remains noisier on the moving version channel. Attempt 2 was slower than attempt 1, but still faster than the no-cache baseline on both Ubuntu and Windows.

Tests

- `git diff --check` - passed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` - passed
- `julia --project=/tmp/qai-fresh.yW7Mre -e 'import Pkg; Pkg.test()'` in a fresh no-manifest checkout - passed
- PR CI run `27128566146` attempt 1 - passed all four matrix jobs
- PR CI run `27128566146` attempt 2 - passed all four matrix jobs
- No separate lint or type-check command is defined in the repo; `rg -n "lint|format|typecheck|type-check|JET|Aqua" README.md Project.toml .github test` found none.

Refs #13
