### PR TITLE
[codex] Update QUBODrivers 0.6 compat and benchmark metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update compatibility to QUBODrivers 0.6.1 and replace the exact LinearSolve
+  pin with lower-bounded compat.
+- Add QUBODrivers benchmark metadata, seed, final-read, and size-limit support.
 - Add README installation instructions for JuMP and QuantumAnnealingInterface.
 - Add TagBot automation for registry-triggered tags.
 - Add Dependabot maintenance for Julia environments and GitHub Actions.

--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,10 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QuantumAnnealing = "4832667a-bab9-40a8-88f6-be9efce3ea89"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-LinearSolve = "=3.82.0"
-QUBODrivers = "0.5"
+LinearSolve = "3.82"
+QUBODrivers = "0.6.1"
 QuantumAnnealing = "0.2"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ Q = [ -1  2  2
 
 optimize!(model)
 ```
+
+## Simulation Size Limit
+
+QuantumAnnealing.jl's state-vector backend builds a dense `2^n` by `2^n`
+density matrix. `QuantumAnnealingInterface.Optimizer` rejects models with more
+than 12 variables by default through the `"max_variables"` optimizer attribute.
+Raise this limit only when the corresponding memory cost is acceptable.

--- a/src/QuantumAnnealingInterface.jl
+++ b/src/QuantumAnnealingInterface.jl
@@ -1,6 +1,7 @@
 module QuantumAnnealingInterface
 
 using LinearAlgebra
+using Random
 using QuantumAnnealing
 import QUBODrivers:
     MOI,
@@ -11,10 +12,14 @@ import QUBODrivers:
     @setup,
     sample
 
+const DEFAULT_MAX_VARIABLES = 12
+const QUANTUM_ANNEALING_VERSION = something(Base.pkgversion(QuantumAnnealing), v"0.2.0")
+
 @setup Optimizer begin
     name       = "Simulated Quantum Annealer"
-    version    = v"0.2.0"
+    version    = QUANTUM_ANNEALING_VERSION
     attributes = begin
+        RandomSeed["seed"]::Union{Integer,Nothing}                = nothing
         NumberOfReads["num_reads"]::Integer                      = 1_000
         "annealing_time"::Float64                                = 1.0
         "annealing_schedule"::QuantumAnnealing.AnnealingSchedule = QuantumAnnealing.AS_LINEAR
@@ -24,8 +29,11 @@ import QUBODrivers:
         "max_tol"::Float64                                       = 1E-4
         "iteration_limit"::Integer                               = 100
         "state_steps"::Union{Integer,Nothing}                    = nothing
+        MaxVariables["max_variables"]::Integer                   = DEFAULT_MAX_VARIABLES
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
 
 const ATTR_LIST = [
     :steps,
@@ -39,14 +47,19 @@ const ATTR_LIST = [
 function sample(sampler::Optimizer{T}) where {T}
     # Retrieve Model
     n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
+    _check_problem_size(n, MOI.get(sampler, MaxVariables()))
     ising_model = merge(h, J)
 
     # Retrieve Attributes
-    m                  = MOI.get(sampler, NumberOfReads())
+    m                  = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
     silent             = MOI.get(sampler, MOI.Silent())
+    seed               = MOI.get(sampler, QUBODrivers.RandomSeed())
     annealing_time     = MOI.get(sampler, MOI.RawOptimizerAttribute("annealing_time"))
     annealing_schedule = MOI.get(sampler, MOI.RawOptimizerAttribute("annealing_schedule"))
-    
+    rng                = _sample_rng(seed)
+
+    _check_final_number_of_reads(m)
+
     attrs = Dict{Symbol,Any}(
         attr => MOI.get(
             sampler,
@@ -70,18 +83,31 @@ function sample(sampler::Optimizer{T}) where {T}
     P = cumsum(real.(diag(ρ)))
 
     # Sample states
-    results = @timed sample_states(P, h, J, α, β, n, m)
+    results = @timed sample_states(rng, P, h, J, α, β, n, m)
     samples = results.value
 
     sampling_time = results.time
 
     # Write metadata
-    metadata = Dict{String,Any}(
-        "origin" => "Quantum Annealing Simulation",
-        "time"   => Dict{String,Any}(
-            "sampling"   => sampling_time,
-            "simulation" => simulation_time,
-            "effective"  => simulation_time + sampling_time,
+    metadata = QUBODrivers._sampler_metadata(
+        origin                = "QuantumAnnealingInterface.jl",
+        algorithm_name        = "Simulated Quantum Annealer",
+        backend_name          = "QuantumAnnealing.jl",
+        backend_version       = QUANTUM_ANNEALING_VERSION,
+        execution_mode        = "state_vector_simulation",
+        optimizer_evaluations = m,
+        number_of_reads       = m,
+        final_number_of_reads = length(samples),
+        status                = "locally_solved",
+        termination_status    = MOI.LOCALLY_SOLVED,
+    )
+    metadata["time"] = Dict{String,Any}(
+        "effective" => simulation_time + sampling_time,
+        "breakdown" => Dict{String,Any}(
+            "QuantumAnnealingInterface" => Dict{String,Any}(
+                "simulation" => simulation_time,
+                "sampling"   => sampling_time,
+            ),
         ),
     )
 
@@ -89,6 +115,7 @@ function sample(sampler::Optimizer{T}) where {T}
 end
 
 function sample_states(
+    rng::Random.AbstractRNG,
     P::Vector{Float64},
     h::Dict{Int,T},
     J::Dict{Tuple{Int,Int},T},
@@ -100,7 +127,7 @@ function sample_states(
     samples = Vector{Sample{T,Int}}(undef, m)
 
     for i = 1:m
-        ψ = sample_state(P, n)
+        ψ = sample_state(rng, P, n)
         λ = QUBOTools.value(ψ, h, J, α, β)
 
         samples[i] = Sample{T,Int}(ψ, λ)
@@ -109,9 +136,9 @@ function sample_states(
     return samples
 end
 
-function sample_state(P::Vector{Float64}, n::Integer)
+function sample_state(rng::Random.AbstractRNG, P::Vector{Float64}, n::Integer)
     # Sample p ~ [0, 1]
-    p = rand()
+    p = rand(rng)
 
     # Run Binary Search
     i = first(searchsorted(P, p))
@@ -120,6 +147,41 @@ function sample_state(P::Vector{Float64}, n::Integer)
     ψ = 2 * digits(Int, i - 1; base=2, pad=n) .- 1
 
     return ψ
+end
+
+function _sample_rng(seed::Union{Integer,Nothing})
+    if isnothing(seed)
+        return Random.default_rng()
+    else
+        return Random.MersenneTwister(seed)
+    end
+end
+
+function _check_final_number_of_reads(m::Integer)
+    if m < 0
+        throw(ArgumentError("Final number of reads must be a non-negative integer"))
+    end
+
+    return nothing
+end
+
+function _check_problem_size(n::Integer, max_variables::Integer)
+    if max_variables < 0
+        throw(ArgumentError("max_variables must be a non-negative integer"))
+    end
+
+    if n > max_variables
+        throw(
+            ArgumentError(
+                "QuantumAnnealingInterface state-vector simulation supports at most " *
+                "$(max_variables) variables by default; got $(n). The backend builds " *
+                "a dense 2^n by 2^n density matrix. Set optimizer attribute " *
+                "\"max_variables\" higher only when that memory cost is acceptable.",
+            ),
+        )
+    end
+
+    return nothing
 end
 
 end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+import TOML
 
 @testset "README installation docs" begin
     readme = read(joinpath(dirname(@__DIR__), "README.md"), String)
@@ -7,6 +8,7 @@ using Test
 
     @test occursin("Pkg.add(\"QuantumAnnealingInterface\")", readme)
     @test occursin("Pkg.add(\"JuMP\")", readme)
+    @test occursin("\"max_variables\"", readme)
     @test installation !== nothing
     @test usage !== nothing
 
@@ -16,7 +18,101 @@ using Test
 end
 
 using QuantumAnnealingInterface: MOI, QUBODrivers, QuantumAnnealingInterface
+const QUBOTools = QuantumAnnealingInterface.QUBOTools
 
-QUBODrivers.test(QuantumAnnealingInterface.Optimizer) do model
+const VI = MOI.VariableIndex
+const SAT{T} = MOI.ScalarAffineTerm{T}
+const SQT{T} = MOI.ScalarQuadraticTerm{T}
+const SQF{T} = MOI.ScalarQuadraticFunction{T}
+
+function configure_test_optimizer!(model)
     MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MOI.RawOptimizerAttribute("steps"), 2)
+    MOI.set(model, MOI.RawOptimizerAttribute("mean_tol"), 1E-3)
+    MOI.set(model, MOI.RawOptimizerAttribute("max_tol"), 1E-3)
+
+    return model
+end
+
+function small_qubo_model(::Type{T} = Float64) where {T}
+    model = MOI.instantiate(QuantumAnnealingInterface.Optimizer; with_bridge_type = T)
+    Q = T[
+        1 -2 3
+        0 -1 -2
+        0 0 2
+    ]
+    n = size(Q, 1)
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{SQF{T}}(),
+        SQF{T}(
+            SQT{T}[SQT{T}(Q[i, j], x[i], x[j]) for i = 1:n for j = 1:n if i != j],
+            SAT{T}[SAT{T}(Q[i, i], x[i]) for i = 1:n],
+            zero(T),
+        ),
+    )
+    configure_test_optimizer!(model)
+
+    return model
+end
+
+function solution_sampleset(model)
+    raw = MOI.get(model, MOI.RawSolver())
+
+    return QUBOTools.solution(raw)
+end
+
+@testset "Compatibility metadata" begin
+    root = dirname(@__DIR__)
+    project = TOML.parsefile(joinpath(root, "Project.toml"))
+    deps = project["deps"]
+    compat = project["compat"]
+
+    @test compat["QUBODrivers"] == "0.6.1"
+    @test haskey(deps, "LinearSolve")
+    @test compat["LinearSolve"] == "3.82"
+    @test compat["LinearSolve"] != "=3.82.0"
+    @test haskey(deps, "Random")
+end
+
+@testset "Benchmark metadata contract" begin
+    @test QUBODrivers.supports_seed(QuantumAnnealingInterface.Optimizer)
+    @test QUBODrivers.honors_final_reads(QuantumAnnealingInterface.Optimizer)
+    @test !QUBODrivers.enforces_time_limit(QuantumAnnealingInterface.Optimizer)
+
+    model = small_qubo_model()
+    MOI.set(model, QUBODrivers.FinalNumberOfReads(), 3)
+    MOI.set(model, QUBODrivers.RandomSeed(), 1234)
+    MOI.optimize!(model)
+
+    sampleset = solution_sampleset(model)
+    metadata = QUBOTools.metadata(sampleset)
+    time_breakdown = metadata["time"]["breakdown"]["QuantumAnnealingInterface"]
+
+    @test length(sampleset) <= 3
+    @test QUBOTools.reads(sampleset) == 3
+    @test isempty(QUBODrivers.validate_metadata(metadata))
+    @test metadata["origin"] == "QuantumAnnealingInterface.jl"
+    @test metadata["algorithm"]["name"] == "Simulated Quantum Annealer"
+    @test metadata["backend"]["name"] == "QuantumAnnealing.jl"
+    @test metadata["reads"]["number_of_reads"] == 3
+    @test metadata["reads"]["final_number_of_reads"] == 3
+    @test metadata["seeds"]["sampler"] == 1234
+    @test metadata["time"]["effective"] > 0.0
+    @test time_breakdown["simulation"] >= 0.0
+    @test time_breakdown["sampling"] >= 0.0
+end
+
+@testset "Simulation size limit" begin
+    model = small_qubo_model()
+    MOI.set(model, MOI.RawOptimizerAttribute("max_variables"), 2)
+
+    @test_throws ArgumentError MOI.optimize!(model)
+end
+
+QUBODrivers.test(QuantumAnnealingInterface.Optimizer; benchmark_conformance = true) do model
+    configure_test_optimizer!(model)
 end


### PR DESCRIPTION
## Summary

- Bumps `QUBODrivers` compat to `0.6.1` and replaces the exact `LinearSolve = "=3.82.0"` pin with lower-bounded `LinearSolve = "3.82"` compat.
- Adds QUBODrivers benchmark metadata schema fields for backend, algorithm, reads, seeds, status, and effective time, with simulation/sampling phase timing under a namespaced breakdown.
- Adds standard `RandomSeed` and `FinalNumberOfReads` behavior, declares final-read support, and documents/enforces a default 12-variable dense state-vector simulation limit.
- Enables `QUBODrivers.test(...; benchmark_conformance = true)` and adds focused compat, metadata, trait, read-count, and size-limit tests.

Refs #15

## Root Cause

The package still targeted `QUBODrivers = "0.5"`, so it could not resolve with the QUBO 0.6 benchmarking stack. The exact LinearSolve pin was also too narrow for ecosystem resolution; the real lower bound is the SciML stack requiring `LinearSolve.LinearVerbosity`, which is present in the 3.82 series and later.

## Tests

- `git diff --check` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed.
  - `Benchmark metadata contract`: 15/15
  - `Simulation size limit`: 1/1
  - `QUBODrivers` suite: 187/187
  - `Benchmark Conformance`: 13/13
- `julia --project=. -e 'using Pkg; dir = mktempdir(); Pkg.activate(dir); Pkg.add(Pkg.PackageSpec(name="QUBO", version="0.6")); Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.status(); eval(:(using QUBO, QuantumAnnealingInterface)); println("QUBO/QuantumAnnealingInterface coexistence OK")'` passed.

Conformance traits:

- `supports_seed = true`
- `honors_final_reads = true`
- `enforces_time_limit = false`

The time-limit acceptance group ran; enforcement-specific timing is not required because this backend does not enforce `MOI.TimeLimitSec()`.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `9856b79f19989db5853b32793415c6c823c243bf`
- Head branch: `fix/issue-15-qubodrivers-compat`
- Stacked status: not stacked
- Prerequisite PRs: none
